### PR TITLE
fix mistake val test split

### DIFF
--- a/peptide_models/train_main.py
+++ b/peptide_models/train_main.py
@@ -106,8 +106,8 @@ def train_multitask_models(iteration: int,
     y2_current = y[1][train_indexes]
     y_current = [y1_current, y2_current]
     # validation/test split
-    test_indexes = test_indexes[:int(len(test_indexes) / 2)]
     val_indexes = test_indexes[int(len(test_indexes) / 2):]
+    test_indexes = test_indexes[:int(len(test_indexes) / 2)]
 
     X_validation = X[val_indexes]
     X_validation = X_validation.reshape(X_validation.shape[0],


### PR DESCRIPTION
Hello,

Thank you for your contribution and for sharing the code, the study is very interesting.

When training the CNN models, the peptides in the validation set were fully included in the test set, leading to a biased model testing. I propose here this little change to fix the issue.

According to the README, "_The folder_ `supporting_experiments` _contains all necessary code and data for replicating the supporting findings_" but it seems to be empty. Could you add the code you are referring to?

Thank you for this.